### PR TITLE
Minor edits to get closer to rubocop passing and fixed spelling error.

### DIFF
--- a/csv_find.gemspec
+++ b/csv_find.gemspec
@@ -1,20 +1,20 @@
 require './lib/csv_find/csv_find'
 
 Gem::Specification.new do |s|
-  s.name = %q{csv_find}
+  s.name = 'csv_find'
   s.version = CsvFind::VERSION
-  s.date = %q{2015-05-22}
+  s.date = '2015-05-22'
   s.authors = ['Mark Platt']
   s.email = 'mplatt@mrkplt.com'
-  s.description = %q{'csv_find will blah blah blah'}
-  s.summary = %q{'blah'}
+  s.description = %q('csv_find will blah blah blah')
+  s.summary = %q('blah')
   s.license = 'MIT'
   s.required_ruby_version = '>= 2.0.0'
   s.test_files = 'spec/csv_find_spec.rb'
   s.files = [
     'lib/csv_find/csv_find.rb'
   ]
-  s.homepage    = 'http://mrkplt.com'
+  s.homepage = 'http://mrkplt.com'
   s.require_paths = ['lib']
 
   s.add_development_dependency 'rspec', '~> 2.14.1'

--- a/lib/csv_find/csv_find.rb
+++ b/lib/csv_find/csv_find.rb
@@ -16,13 +16,13 @@ module CsvFind
     attr_accessor :line_number
 
     def initialize(hash = {})
-      hash.each { |k,v| send("#{k}=".to_sym, v) }
+      hash.each { |k, v| send("#{k}=".to_sym, v) }
     end
 
-    def ==(other_instance)
+    def ==(other)
       instance_variables.map do |instance_variable|
         instance_variable_get(instance_variable) ==
-          other_instance.instance_variable_get(instance_variable)
+          other.instance_variable_get(instance_variable)
       end
     end
 
@@ -42,7 +42,7 @@ module CsvFind
       @file = CSV.new(File.open(file_name, 'r'), @file_options)
       @first_line = 2
       @last_line = `wc -l #{file_name}`.split(' ').first.to_i
-      @middle_line = (@last_line/2) + 1
+      @middle_line = (@last_line / 2) + 1
       @line_number = nil
       @headers = extract_headers(file_name, file_options)
 
@@ -77,10 +77,10 @@ module CsvFind
 
     def find(line_number)
       row = if (first_line..middle_line).include?(line_number)
-        front_find(line_number, file.path)
-      else
-        back_find(line_number, file.path)
-      end
+              front_find(line_number, file.path)
+            else
+              back_find(line_number, file.path)
+            end
 
       row.nil? ? row : build_instance(row, line_number)
     end
@@ -105,9 +105,8 @@ module CsvFind
 
     private
 
-    DEPRECATION_MESSAGE =
-      '[DEPRECATION] This method is deprecated and will be removed in v2.' <<
-      'Please user #where.'
+    DEPRECATION_MESSAGE = '[DEPRECATION] This method is deprecated and will '\
+                          'be removed in v2. Please use #where.'
 
     def default_options
       {
@@ -118,7 +117,7 @@ module CsvFind
     end
 
     def extract_headers(file_name, options)
-      csv_file = File.open(file_name,'r')
+      csv_file = File.open(file_name, 'r')
       CSV.new(csv_file, options).first.headers
     end
 
@@ -147,7 +146,7 @@ module CsvFind
     def dig(hash_pair, rows)
       rows.select do |row|
         if row[hash_pair.first] == hash_pair.last
-          $. != last_line ? row.push(line_number: $.) : row
+          $NR != last_line ? row.push(line_number: $NR) : row
         end
       end
     end

--- a/spec/csv_find_spec.rb
+++ b/spec/csv_find_spec.rb
@@ -6,97 +6,116 @@ class People
 end
 
 describe People do
-  before(:all){
-    @person1 = People.new(first: 'Mark', last: 'Platt', nickname: 'JCool', line_number: 2)
-    @person2 = People.new(first: 'Longinus', last: 'Smith', nickname: 'Pebbles', line_number: 3)
-    @person3 = People.new(first: 'Johnny', last: 'Radiation', nickname: 'Pebbles', line_number: 4)
-    @person4 = People.new(first: 'Charlie', last: 'Mansfield', nickname: 'Sammykins', line_number: 5)
-  }
+  let(:person1) do
+    People.new(first: 'Mark', last: 'Platt', nickname: 'JCool', line_number: 2)
+  end
+
+  let(:person2) do
+    People.new(first: 'Longinus',
+               last: 'Smith',
+               nickname: 'Pebbles',
+               line_number: 3)
+  end
+
+  let(:person3) do
+    People.new(first: 'Johnny',
+               last: 'Radiation',
+               nickname: 'Pebbles',
+               line_number: 4)
+  end
+
+  let(:person4) do
+    People.new(first: 'Charlie',
+               last: 'Mansfield',
+               nickname: 'Sammykins',
+               line_number: 5)
+  end
 
   context 'class methods' do
-    it "responds to .first" do
+    it 'responds to .first' do
       (People).should respond_to(:first)
     end
 
-    it ".first returns correctly" do
-      expect(People.first).to eq @person1
+    it '.first returns correctly' do
+      expect(People.first).to eq person1
     end
 
-    it "responds to .last" do
+    it 'responds to .last' do
       (People).should respond_to(:last)
     end
 
-    it ".last returns correctly" do
-      expect(People.last).to eq @person4
+    it '.last returns correctly' do
+      expect(People.last).to eq person4
     end
 
-    it "responds to .find" do
+    it 'responds to .find' do
       (People).should respond_to(:find)
     end
 
-    it ".find returns correctly" do
-      expect(People.find(2)).to eq @person1
-      expect(People.find(3)).to eq @person2
-      expect(People.find(4)).to eq @person3
-      expect(People.find(5)).to eq @person4
+    it '.find returns correctly' do
+      expect(People.find(2)).to eq person1
+      expect(People.find(3)).to eq person2
+      expect(People.find(4)).to eq person3
+      expect(People.find(5)).to eq person4
     end
 
-    it "[DEPRECATED] responds to .find_by" do
+    it '[DEPRECATED] responds to .find_by' do
       (People).should respond_to(:find_by)
     end
 
-    it "[DEPRECATED] .find_by returns correctly" do
-      expect(People.find_by(nickname: 'Pebbles')).to eq @person3
-      expect(People.find_by(nickname: 'Pebbles', last: 'Smith')).to eq @person2
+    it '[DEPRECATED] .find_by returns correctly' do
+      expect(People.find_by(nickname: 'Pebbles')).to eq person3
+      expect(People.find_by(nickname: 'Pebbles', last: 'Smith')).to eq person2
     end
 
-    it ".find_by returns an nil if there are no results" do
+    it '.find_by returns an nil if there are no results' do
       expect(People.find_by(nickname: 'Beastmode')).to eq nil
     end
 
-
-    it "responds to .where" do
+    it 'responds to .where' do
       (People).should respond_to(:where)
     end
 
-    it ".where returns correctly" do
-      expect(People.where(nickname: 'Pebbles')).to eq [@person2, @person3]
-      expect(People.where(nickname: 'Pebbles', last: 'Radiation')).to eq [@person3]
+    it '.where returns correctly' do
+      expect(People.where(nickname: 'Pebbles')).to eq [person2, person3]
+      expect(People.where(nickname: 'Pebbles', last: 'Radiation'))
+        .to eq [person3]
     end
 
-    it ".where returns an empty array if there are no results" do
+    it '.where returns an empty array if there are no results' do
       expect(People.where(nickname: 'Beastmode')).to eq []
     end
 
-    it "[DEPRECATED] responds to .find_all_by" do
+    it '[DEPRECATED] responds to .find_all_by' do
       (People).should respond_to(:find_all_by)
     end
 
-    it "[DEPRECATED] .find_all_by returns correctly" do
-      expect(People.find_all_by(nickname: 'Pebbles')).to eq [@person2, @person3]
-      expect(People.find_all_by(nickname: 'Pebbles', last: 'Radiation')).to eq [@person3]
+    it '[DEPRECATED] .find_all_by returns correctly' do
+      expect(People.find_all_by(nickname: 'Pebbles')).to eq [person2, person3]
+      expect(People.find_all_by(nickname: 'Pebbles', last: 'Radiation'))
+        .to eq [person3]
     end
 
-    it "responds to .each" do
+    it 'responds to .each' do
       (People).should respond_to(:each)
     end
 
-    it ".each line yields" do
+    it '.each line yields' do
       @output = []
-      People.each{ |person| @output << person.first }
-      expect(@output).to eq ['Mark', 'Longinus', 'Johnny', 'Charlie']
+      People.each { |person| @output << person.first }
+      expect(@output).to eq %w(Mark Longinus Johnny Charlie)
     end
   end
   context 'instance methods' do
-    it "responds to .first as defined in the csv" do
+    it 'responds to .first as defined in the csv' do
       (People.new).should respond_to(:first)
     end
 
-    it "responds to .last as defined in the csv" do
+    it 'responds to .last as defined in the csv' do
       (People.new).should respond_to(:last)
     end
 
-    it "responds to .nickname as defined in the csv" do
+    it 'responds to .nickname as defined in the csv' do
       (People.new).should respond_to(:nickname)
     end
   end


### PR DESCRIPTION
DEPRECATION_MESSAGE said Please user #where. Random minor edits based on a run on Rubocop. There are a handful of other issues outstanding - figure they will shake themselves out.

```
Offenses:

csv_find.gemspec:9:19: C: Use %q only for strings that contain both single quotes and double quotes.
  s.description = %q('csv_find will blah blah blah')
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
csv_find.gemspec:10:15: C: Use %q only for strings that contain both single quotes and double quotes.
  s.summary = %q('blah')
              ^^^^^^^^^^
lib/csv_find/csv_find.rb:1:1: C: Missing top-level module documentation comment.
module CsvFind
^^^^^^
lib/csv_find/csv_find.rb:15:3: C: Missing top-level module documentation comment.
  module InstanceMethods
  ^^^^^^
lib/csv_find/csv_find.rb:34:3: C: Module has too many lines. [102/100]
  module ClassMethods
  ^^^^^^
lib/csv_find/csv_find.rb:34:3: C: Missing top-level module documentation comment.
  module ClassMethods
  ^^^^^^
lib/csv_find/csv_find.rb:155:81: C: Line is too long. [91/80]
      command = `head -n 1 #{file_path} && head -n #{line_number} #{file_path} | tail -n 1`
                                                                                ^^^^^^^^^^^
lib/csv_find/csv_find.rb:160:81: C: Line is too long. [109/80]
      command = `head -n 1 #{file_path} && tail -n #{(last_line + 1) - line_number} #{file_path} | head -n 1`
                                                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/csv_find_spec.rb:3:1: C: Missing top-level class documentation comment.
class People
```
